### PR TITLE
Use `main` branch instead of `master`

### DIFF
--- a/R/tldr.R
+++ b/R/tldr.R
@@ -11,7 +11,7 @@ tldr <- function(command, platform = get_platform()) {
 }
 
 make_url <- function(platform, command) {
-  BASE_URL <- "https://raw.github.com/tldr-pages/tldr/master/pages/"
+  BASE_URL <- "https://raw.github.com/tldr-pages/tldr/main/pages/"
   paste0(BASE_URL, platform, "/", command, ".md")
 }
 


### PR DESCRIPTION
[About 1.5 years ago](https://github.com/tldr-pages/tldr/discussions/5868), we deprecated the `master` branch in favor of the `main` branch. We intend to remove it [soon, likely by May 1st 2023](https://github.com/tldr-pages/tldr/issues/9628).